### PR TITLE
refine 2025 project brief template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 VibeCO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: render test clean
+
+render:
+	python scripts/render.py
+
+test:
+	pytest
+
+clean:
+	rm -f PROJECT_SUMMARY.md

--- a/README.md
+++ b/README.md
@@ -1,112 +1,194 @@
 # VibeCO
-Vibe Coding Orchestrator
 
-# Reviewer
-Kod/doküman inceleme.
-FILE: agents/roles/QA.md
+Welcome to the 2025 edition of **VibeCO (Vibe Coding Orchestrator)**—a reusable project brief template designed so that every stakeholder immediately understands what you are building, why it matters, and how to unlock the next phase of work. Clone this repository, inject your own context, and publish a polished brief that keeps your team aligned from day zero.
 
-markdown
-Kodu kopyala
-# QA
-Test ve kalite kapısı.
-FILE: .github/workflows/ci.yml
+## Why this repository exists
 
-yaml
-Kodu kopyala
-name: ci
-on:
-  pull_request:
-  push:
-    branches: [ main, master ]
+Modern software projects evolve quickly. VibeCO keeps your source-of-truth lightweight, explicit, and testable so you can:
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: python -m pip install --upgrade pip
-      - run: pip install -r requirements.txt
-      - run: make ci
-FILE: .github/ISSUE_TEMPLATE/agent_proposal.yml
+- Capture your mission, values, expert advisors, and progress snapshots in a single YAML document.
+- Render a consistently formatted summary using Jinja2 and share it as `PROJECT_SUMMARY.md`.
+- Record when a stakeholder provides the **`Next`** keyword that unlocks the following delivery step.
+- Provide approximate percentage-based progress updates so readers always know how close you are to completion.
 
-yaml
-Kodu kopyala
-name: Agent Proposal (RFC)
-description: Bir agent'tan öneri / plan değişikliği
-title: "RFC: <kısa başlık>"
-labels: ["agent", "proposal"]
-body:
-  - type: textarea
-    attributes:
-      label: Problem / Fırsat
-      description: Neyi çözmek istiyoruz?
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Öneri
-      description: Yaklaşım, kapsam ve etkiler
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Test Stratejisi
-      description: Başarıyı nasıl doğrulayacağız?
-    validations:
-      required: true
-FILE: .github/ISSUE_TEMPLATE/task.yml
+## What’s included
 
-yaml
-Kodu kopyala
-name: Task
-description: Plan maddesine karşılık gelen iş
-title: "<STEP-ID> <kısa açıklama>"
-labels: ["task"]
-body:
-  - type: input
-    attributes:
-      label: STEP-ID
-      description: PLAN.md'deki adım kimliği (örn. STEP-003)
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Kabul Kriterleri
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Testler
-    validations:
-      required: true
-🚀 Git ve Yayın Komutları (örnek)
-bash
-Kodu kopyala
-git init
-git add .
-git commit -m "chore: bootstrap agent plan template"
+- **Structured data model (`project.yaml`)** covering objectives, roadmap, experts, quality gates, and progress percentages.
+- **Markdown rendering template** (`docs/project_summary_template.md`) that transforms the data into a public-friendly briefing.
+- **Rendering utility** (`scripts/render.py`) with a Makefile target for repeatable builds.
+- **Pytest suite** validating the renderer’s core behaviours, so the workflow stays trustworthy.
 
-# GitHub: gh CLI varsa
-gh repo create YOUR_GITHUB_USER_OR_ORG/agent-plan-template --public --source=. --push
+## Quick start (2025 workflow)
 
-# gh yoksa (HTTPS):
-git branch -M main
-git remote add origin https://github.com/YOUR_GITHUB_USER_OR_ORG/agent-plan-template.git
-git push -u origin main
-✅ Doğrulama
-bash
-Kodu kopyala
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-make ci
-python scripts/next.py --dry-run
-python scripts/next.py --lock     # ilk adımı kilitle
-python scripts/next.py            # adımı [x] yapar ve PLAN.md'yi günceller
-python scripts/next.py --unlock   # kilitleri temizler
+1. Fork or clone this repository.
+2. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. Copy and personalize the project data:
+   ```bash
+   cp project.yaml.example project.yaml
+   ```
+4. Replace the placeholder content in `project.yaml` with your project’s realities. Update progress percentages, document the experts you consult, and note who can speak the `Next` keyword for each stage.
+5. Generate the shareable summary:
+   ```bash
+   make render
+   ```
+6. Review the generated `PROJECT_SUMMARY.md`. When it looks right, commit both `project.yaml` and the rendered summary.
+7. Run the automated checks:
+   ```bash
+   pytest
+   ```
+8. Publish your repository or share the rendered brief with your collaborators. Each time you receive a new command or the `Next` keyword, update the YAML and re-render.
 
-GitHub Actions’a otomatik “progress badge” güncellemesi ekleyelim.
+## ASCII workflow for new commands
 
-“priority lanes” ve “blocked-by” etiketleriyle depends_on’u Issue otomasyonuna bağlayalım.
+When a new instruction arrives, follow this repeatable path to keep the brief reliable:
+
+```
+┌────────────┐    Next keyword?    ┌────────────┐
+│ Receive cmd│ ───────────────────►│ Validate   │
+└─────┬──────┘        yes/no       └─────┬──────┘
+      │                               │
+      │ no                            │ yes
+      ▼                               ▼
+┌────────────┐    clarify intent   ┌────────────┐
+│ Ask details│ ◄────────────────── │ Update data│
+└─────┬──────┘                      └─────┬──────┘
+      │                                   │
+      ▼                                   ▼
+┌────────────┐    run tests        ┌────────────┐
+│ Render md  │────────────────────►│ Share brief│
+└────────────┘                     └────────────┘
+```
+
+Refer back to this diagram whenever you iterate—the `Next` keyword gates your advancement to the next milestone.
+
+## Project data structure
+
+All canonical information lives in `project.yaml`. The schema below reflects the 2025 defaults. You can freely extend or trim fields; the renderer mirrors what you provide.
+
+```yaml
+name: Sample Project
+slug: sample-project
+status: exploring
+tagline: Write a short, inspiring one-liner.
+owners:
+  - name: Ada Lovelace
+    role: Founder
+    contact: ada@example.com
+overview:
+  problem: What are you trying to solve?
+  solution: How will you solve it?
+  impact: What value will this deliver?
+values:
+  - name: Transparency
+    description: Communicate openly and share progress often.
+  - name: Quality
+    description: Deliver maintainable, well-tested software.
+experts:
+  - name: Dr. Grace Hopper
+    speciality: Systems architecture
+    advice: Keep interfaces decoupled and well documented.
+quality_gates:
+  - name: Automated tests
+    description: "pytest must pass before sharing updates."
+  - name: Peer review
+    description: A domain expert must approve each milestone.
+objectives:
+  - title: Launch an MVP
+    status: planned
+    progress_percent: 35
+    next_keyword_holder: Product sponsor
+    success_metrics:
+      - 50 early-access signups
+      - Collect qualitative feedback from 10 users
+    notes: Focus on the must-have journey only.
+  - title: Automate CI pipeline
+    status: planned
+    progress_percent: 10
+    next_keyword_holder: Platform lead
+    success_metrics:
+      - Tests run on every pull request
+      - Deployment button for staging
+roadmap:
+  - milestone: Foundation
+    due: 2025-03-15
+    owner: Ada Lovelace
+    focus: Authentication, project setup
+  - milestone: Beta
+    due: 2025-06-01
+    owner: Ada Lovelace
+    focus: Onboarding, feedback loop
+progress_updates:
+  - date: 2025-01-05
+    percent_complete: 25
+    summary: Core architecture reviewed by experts; waiting on Next keyword.
+  - date: 2025-02-12
+    percent_complete: 40
+    summary: MVP endpoints coded and passing pytest suite.
+artifacts:
+  code: https://github.com/your-user/your-repo
+  design: https://www.figma.com/file/.../your-designs
+  docs: https://docs.example.com/project
+notes: Include any additional context your stakeholders should know.
+```
+
+### Tips for tailoring the data
+
+- **Track progress responsibly:** Percentages do not need to be perfect; aim for realistic snapshots so readers understand momentum.
+- **Highlight expert insight:** Add as many experts as you consult. Their guidance builds trust in your plan.
+- **Record Next keyword owners:** For every objective, specify who can supply `Next` to unlock subsequent work.
+- **Document quality gates:** List every test or review you must pass before announcing progress.
+
+## Rendering workflow
+
+The `scripts/render.py` script reads `project.yaml`, renders the markdown template (`docs/project_summary_template.md`), and writes the finished document to `PROJECT_SUMMARY.md`.
+
+To run it manually:
+
+```bash
+python scripts/render.py
+```
+
+Prefer `make render` for a one-line command that resolves paths correctly.
+
+Whenever you change `project.yaml`, re-render and commit both the data and output. This keeps your brief auditable.
+
+## Directory layout
+
+```
+.
+├── README.md
+├── Makefile
+├── requirements.txt
+├── project.yaml.example
+├── docs/
+│   └── project_summary_template.md
+├── scripts/
+│   └── render.py
+├── samples/
+│   └── PROJECT_SUMMARY.sample.md
+└── tests/
+    └── test_render.py
+```
+
+## Customize the template
+
+- **Data model freedom:** Add fields for budgets, design tokens, or anything else. Undefined values simply won’t render.
+- **Layout control:** Adjust headings or add tables in `docs/project_summary_template.md` to match your communication style.
+- **Automation friendly:** Use the `--data`, `--template`, and `--output` flags in `scripts/render.py` to integrate rendering into CI/CD pipelines.
+
+## Sharing your project
+
+Once `PROJECT_SUMMARY.md` looks right:
+
+- Publish it as the main README of your project repository.
+- Share it with stakeholders so they can review progress, expert advice, and `Next` keyword ownership.
+- Update it after every milestone, expert review, or major command. Re-run the tests and renderer before communicating updates.
+
+## License
+
+This template is released under the [MIT License](LICENSE). You can reuse and adapt it for any purpose.

--- a/docs/project_summary_template.md
+++ b/docs/project_summary_template.md
@@ -1,0 +1,68 @@
+# {{ project.get('name', 'Untitled Project') }}
+
+> {{ project.get('tagline', 'Describe your project in one sentence.') }}
+
+{% if project.get('status') %}**Current status:** {{ project['status'] | replace('_', ' ') | title }}
+{% endif %}{% if project.get('owners') %}
+**Owners**
+{% for owner in project['owners'] %}- {{ owner.get('name', 'Owner') }}{% if owner.get('role') %} — {{ owner['role'] }}{% endif %}{% if owner.get('contact') %} (<{{ owner['contact'] }}>) {% endif %}
+{% endfor %}{% endif %}
+
+{% if project.get('overview') %}
+## Overview
+{% set overview = project['overview'] %}{% if overview.get('problem') %}- **Problem**: {{ overview['problem'] }}
+{% endif %}{% if overview.get('solution') %}- **Solution**: {{ overview['solution'] }}
+{% endif %}{% if overview.get('impact') %}- **Impact**: {{ overview['impact'] }}
+{% endif %}{% endif %}
+
+{% if project.get('values') %}
+## Core Values
+{% for value in project['values'] %}- **{{ value.get('name', 'Value') }}** — {{ value.get('description', '') }}
+{% endfor %}{% endif %}
+
+{% if project.get('experts') %}
+## Expert Advisors
+{% for expert in project['experts'] %}- **{{ expert.get('name', 'Expert') }}**{% if expert.get('speciality') %} ({{ expert['speciality'] }}){% endif %}: {{ expert.get('advice', 'Guidance forthcoming.') }}
+{% endfor %}{% endif %}
+
+{% if project.get('quality_gates') %}
+## Quality Gates
+{% for gate in project['quality_gates'] %}- **{{ gate.get('name', 'Gate') }}** — {{ gate.get('description', '') }}
+{% endfor %}{% endif %}
+
+{% if project.get('objectives') %}
+## Objectives & Success Criteria
+{% for objective in project['objectives'] %}
+### {{ objective.get('title', 'Objective') }}
+- **Status**: {{ objective.get('status', 'planned') | replace('_', ' ') | title }}
+{% if objective.get('progress_percent') is not none %}- **Progress**: {{ objective['progress_percent'] }}%
+{% endif %}{% if objective.get('next_keyword_holder') %}- **Next keyword holder**: {{ objective['next_keyword_holder'] }}
+{% endif %}{% if objective.get('success_metrics') %}- **Success metrics**:
+{% for metric in objective['success_metrics'] %}  - {{ metric }}
+{% endfor %}{% endif %}{% if objective.get('notes') %}- **Notes**: {{ objective['notes'] }}
+{% endif %}
+{% endfor %}{% endif %}
+
+{% if project.get('progress_updates') %}
+## Progress Updates
+| Date | Completion | Summary |
+|------|------------|---------|
+{% for update in project['progress_updates'] %}| {{ update.get('date', 'TBD') }} | {{ update.get('percent_complete', '0') }}% | {{ update.get('summary', '') }} |
+{% endfor %}{% endif %}
+
+{% if project.get('roadmap') %}
+## Roadmap
+| Milestone | Due date | Owner | Focus |
+|-----------|----------|-------|-------|
+{% for item in project['roadmap'] %}| {{ item.get('milestone', 'TBD') }} | {{ item.get('due', 'TBD') }} | {{ item.get('owner', 'TBD') }} | {{ item.get('focus', '') }} |
+{% endfor %}{% endif %}
+
+{% if project.get('artifacts') %}
+## Reference Links
+{% for name, link in project['artifacts'].items() %}- **{{ name | replace('_', ' ') | title }}**: {{ link }}
+{% endfor %}{% endif %}
+
+{% if project.get('notes') %}
+## Additional Notes
+{{ project['notes'] }}
+{% endif %}

--- a/project.yaml.example
+++ b/project.yaml.example
@@ -1,0 +1,63 @@
+name: Sample Project
+slug: sample-project
+status: exploring
+tagline: Write a short, inspiring one-liner.
+owners:
+  - name: Ada Lovelace
+    role: Founder
+    contact: ada@example.com
+overview:
+  problem: What are you trying to solve?
+  solution: How will you solve it?
+  impact: What value will this deliver?
+values:
+  - name: Transparency
+    description: Communicate openly and share progress often.
+  - name: Quality
+    description: Deliver maintainable, well-tested software.
+experts:
+  - name: Dr. Grace Hopper
+    speciality: Systems architecture
+    advice: Keep interfaces decoupled and well documented.
+quality_gates:
+  - name: Automated tests
+    description: "pytest must pass before sharing updates."
+  - name: Peer review
+    description: A domain expert must approve each milestone.
+objectives:
+  - title: Launch an MVP
+    status: planned
+    progress_percent: 35
+    next_keyword_holder: Product sponsor
+    success_metrics:
+      - 50 early-access signups
+      - Collect qualitative feedback from 10 users
+    notes: Focus on the must-have journey only.
+  - title: Automate CI pipeline
+    status: planned
+    progress_percent: 10
+    next_keyword_holder: Platform lead
+    success_metrics:
+      - Tests run on every pull request
+      - Deployment button for staging
+roadmap:
+  - milestone: Foundation
+    due: 2025-03-15
+    owner: Ada Lovelace
+    focus: Authentication, project setup
+  - milestone: Beta
+    due: 2025-06-01
+    owner: Ada Lovelace
+    focus: Onboarding, feedback loop
+progress_updates:
+  - date: 2025-01-05
+    percent_complete: 25
+    summary: Core architecture reviewed by experts; waiting on Next keyword.
+  - date: 2025-02-12
+    percent_complete: 40
+    summary: MVP endpoints coded and passing pytest suite.
+artifacts:
+  code: https://github.com/your-user/your-repo
+  design: https://www.figma.com/file/.../your-designs
+  docs: https://docs.example.com/project
+notes: Include any additional context your stakeholders should know.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Jinja2==3.1.3
+PyYAML==6.0.1
+pytest==8.1.1

--- a/samples/PROJECT_SUMMARY.sample.md
+++ b/samples/PROJECT_SUMMARY.sample.md
@@ -1,0 +1,59 @@
+# Sample Project
+
+> Write a short, inspiring one-liner.
+
+**Current status:** Exploring
+**Owners**
+- Ada Lovelace — Founder (<ada@example.com>) 
+## Overview
+- **Problem**: What are you trying to solve?
+- **Solution**: How will you solve it?
+- **Impact**: What value will this deliver?
+
+## Core Values
+- **Transparency** — Communicate openly and share progress often.
+- **Quality** — Deliver maintainable, well-tested software.
+
+## Expert Advisors
+- **Dr. Grace Hopper** (Systems architecture): Keep interfaces decoupled and well documented.
+
+## Quality Gates
+- **Automated tests** — pytest must pass before sharing updates.
+- **Peer review** — A domain expert must approve each milestone.
+
+## Objectives & Success Criteria
+### Launch an MVP
+- **Status**: Planned
+- **Progress**: 35%
+- **Next keyword holder**: Product sponsor
+- **Success metrics**:
+  - 50 early-access signups
+  - Collect qualitative feedback from 10 users
+- **Notes**: Focus on the must-have journey only.
+### Automate CI pipeline
+- **Status**: Planned
+- **Progress**: 10%
+- **Next keyword holder**: Platform lead
+- **Success metrics**:
+  - Tests run on every pull request
+  - Deployment button for staging
+
+## Progress Updates
+| Date | Completion | Summary |
+|------|------------|---------|
+| 2025-01-05 | 25% | Core architecture reviewed by experts; waiting on Next keyword. |
+| 2025-02-12 | 40% | MVP endpoints coded and passing pytest suite. |
+
+## Roadmap
+| Milestone | Due date | Owner | Focus |
+|-----------|----------|-------|-------|
+| Foundation | 2025-03-15 | Ada Lovelace | Authentication, project setup |
+| Beta | 2025-06-01 | Ada Lovelace | Onboarding, feedback loop |
+
+## Reference Links
+- **Code**: https://github.com/your-user/your-repo
+- **Design**: https://www.figma.com/file/.../your-designs
+- **Docs**: https://docs.example.com/project
+
+## Additional Notes
+Include any additional context your stakeholders should know.

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -1,0 +1,77 @@
+"""Render PROJECT_SUMMARY.md from project.yaml using a markdown template."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render PROJECT_SUMMARY.md by combining project.yaml with "
+            "docs/project_summary_template.md."
+        )
+    )
+    parser.add_argument(
+        "--data",
+        default="project.yaml",
+        type=Path,
+        help="Path to the YAML file that describes the project.",
+    )
+    parser.add_argument(
+        "--template",
+        default=Path("docs") / "project_summary_template.md",
+        type=Path,
+        help="Path to the markdown template that should be rendered.",
+    )
+    parser.add_argument(
+        "--output",
+        default=Path("PROJECT_SUMMARY.md"),
+        type=Path,
+        help="Where to write the rendered markdown file.",
+    )
+    return parser
+
+
+def load_project_data(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"Project data not found: {path}. Create it from project.yaml.example first.")
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise SystemExit("project.yaml must contain a mapping at the top level.")
+    return data
+
+
+def render_template(template_path: Path, context: dict) -> str:
+    if not template_path.exists():
+        raise SystemExit(f"Template file not found: {template_path}")
+    env = Environment(
+        loader=FileSystemLoader(str(template_path.parent)),
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = env.get_template(template_path.name)
+    content = template.render(project=context).strip()
+    return content + "\n"
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    project_data = load_project_data(args.data)
+    output = render_template(args.template, project_data)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(output, encoding="utf-8")
+    print(f"Rendered {args.output} from {args.data} using {args.template}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.render import load_project_data, render_template
+
+
+def test_load_project_data_requires_mapping(tmp_path: Path) -> None:
+    data_file = tmp_path / "project.yaml"
+    data_file.write_text("- not-a-mapping", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        load_project_data(data_file)
+
+    assert "mapping" in str(excinfo.value)
+
+
+def test_render_template_includes_progress_sections(tmp_path: Path) -> None:
+    template_path = tmp_path / "template.md"
+    template_path.write_text(
+        "Progress: {% for update in project['progress_updates'] %}{{ update['percent_complete'] }}% {% endfor %}",
+        encoding="utf-8",
+    )
+
+    context = {
+        "progress_updates": [
+            {"date": "2025-01-05", "percent_complete": 25, "summary": "Checkpoint"},
+            {"date": "2025-02-12", "percent_complete": 40, "summary": "More progress"},
+        ]
+    }
+
+    rendered = render_template(template_path, context)
+
+    assert "25%" in rendered
+    assert "40%" in rendered


### PR DESCRIPTION
## Summary
- rewrite the README to explain the 2025 workflow, the `Next` keyword gate, ASCII command flow, and detailed usage guidance
- enrich the data model, template, and sample output with expert input, quality gates, progress percentages, and periodic updates
- add a pytest dependency, renderer unit tests, and a Makefile test target to keep the template validated

## Testing
- make render (with project.yaml copied from project.yaml.example)
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5265cf3fc832ba8b9f95a65ca1a1c