### PR TITLE
Add badges and secret guard for daily stability workflow

### DIFF
--- a/.github/workflows/daily_stability.yml
+++ b/.github/workflows/daily_stability.yml
@@ -11,6 +11,7 @@ jobs:
       contents: write
       issues: write
     env:
+      OWNER: "@Neudzulab"
       PROD_BASE_URL: ${{ secrets.PROD_BASE_URL }}
       PROD_API_TOKEN: ${{ secrets.PROD_API_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -19,10 +20,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Check secrets
+        run: python scripts/daily/check_secrets.py || echo "secrets-missing" > .secmiss
       - run: python -m pip install --upgrade pip
+        if: hashFiles('.secmiss') == ''
       - run: pip install -r requirements.txt
+        if: hashFiles('.secmiss') == ''
       - name: Run daily stabilization suite
         run: python scripts/daily/run_all.py
+        if: hashFiles('.secmiss') == ''
       - name: Commit daily report
         run: |
           d=$(date -u +"%Y-%m-%d")
@@ -31,6 +37,7 @@ jobs:
           git add reports/daily/$d.md artifacts/*.json || true
           git commit -m "chore(prod): daily report $d" || echo "no changes"
           git push || true
+        if: hashFiles('.secmiss') == ''
       - name: Open issues on breach
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,18 +59,31 @@ jobs:
               token = env.get("GITHUB_TOKEN")
               if token:
                   env["GH_TOKEN"] = token
+              owner = env.get("OWNER", "")
+              assignee = owner.lstrip("@") if owner else ""
+              cmd = [
+                  "gh",
+                  "issue",
+                  "create",
+                  "-t",
+                  title,
+                  "-b",
+                  body,
+                  "-l",
+                  "stability,prod",
+              ]
+              if assignee:
+                  cmd.extend(["-a", assignee])
               try:
-                  subprocess.check_call([
-                      "gh",
-                      "issue",
-                      "create",
-                      "-t",
-                      title,
-                      "-b",
-                      body,
-                      "-l",
-                      "stability,prod",
-                  ], env=env)
+                  subprocess.check_call(cmd, env=env)
               except Exception as exc:
                   print(f"gh issue create failed: {exc}")
           PY
+        if: hashFiles('.secmiss') == ''
+      - name: Open missing-secrets issue
+        if: hashFiles('.secmiss') != ''
+        run: |
+          owner="${OWNER#@}"
+          gh issue create -t "Stability: missing secrets" -b "Please set PROD_BASE_URL & PROD_API_TOKEN" -l "prod,stability" ${owner:+-a "$owner"}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # VibeCO
 
+[![refactor-guard](https://github.com/Neudzulab/VibeCO/actions/workflows/refactor.yml/badge.svg)](./.github/workflows/refactor.yml)
+[![daily-stability](https://github.com/Neudzulab/VibeCO/actions/workflows/daily_stability.yml/badge.svg)](./.github/workflows/daily_stability.yml)
+
 Welcome to the 2025 edition of **VibeCO (Vibe Coding Orchestrator)**—a reusable project brief template designed so that every stakeholder immediately understands what you are building, why it matters, and how to unlock the next phase of work. Clone this repository, inject your own context, and publish a polished brief that keeps your team aligned from day zero.
 
 ## Why this repository exists
@@ -42,6 +45,18 @@ Modern software projects evolve quickly. VibeCO keeps your source-of-truth light
    pytest
    ```
 8. Publish your repository or share the rendered brief with your collaborators. Each time you receive a new command or the `Next` keyword, update the YAML and re-render.
+
+## Run locally
+
+Reproduce the daily stability workflow on your workstation:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pytest -q
+# rehearse the daily stabilization locally
+python scripts/daily/run_all.py
+```
 
 ## ASCII workflow for new commands
 

--- a/scripts/daily/check_secrets.py
+++ b/scripts/daily/check_secrets.py
@@ -1,0 +1,30 @@
+"""Check that required production secrets are available.
+
+The daily stability workflow depends on PROD_BASE_URL and PROD_API_TOKEN.
+This helper exits with status code 2 when any required secret is missing
+and prints a marker for each absent variable so the CI job can react.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+REQUIRED_SECRETS = ("PROD_BASE_URL", "PROD_API_TOKEN")
+
+
+def main() -> int:
+    missing = []
+    for name in REQUIRED_SECRETS:
+        value = os.getenv(name)
+        if not value:
+            print(f"MISSING:{name}")
+            missing.append(name)
+    if missing:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add refactor-guard and daily-stability badges and document the local rehearsal commands in the README
- add a helper that verifies required secrets and gate the daily-stability workflow on it
- file GitHub issues and assign @Neudzulab automatically when stability checks or required secrets fail

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e545007d6c832ba8b58d32e80c900b