### PR TITLE
Fix CI workflow to execute in arylen-agent directory

### DIFF
--- a/arylen-agent/.github/workflows/ci.yml
+++ b/arylen-agent/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PROJECT_DIR: arylen-agent
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -16,9 +18,23 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
+          PROJECT_DIR=${PROJECT_DIR:-.}
+          if [ -d "$PROJECT_DIR" ]; then
+              cd "$PROJECT_DIR"
+          fi
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Lint
-        run: make lint
+        run: |
+          PROJECT_DIR=${PROJECT_DIR:-.}
+          if [ -d "$PROJECT_DIR" ]; then
+              cd "$PROJECT_DIR"
+          fi
+          make lint
       - name: Test
-        run: make test
+        run: |
+          PROJECT_DIR=${PROJECT_DIR:-.}
+          if [ -d "$PROJECT_DIR" ]; then
+              cd "$PROJECT_DIR"
+          fi
+          make test


### PR DESCRIPTION
## Summary
- ensure the CI workflow steps run inside the arylen-agent directory when it exists so the correct requirements and Makefile are used

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e56a84da4c832bab5858607663eff3